### PR TITLE
Add Mellanox Support

### DIFF
--- a/hack/build-dpdkapp.sh
+++ b/hack/build-dpdkapp.sh
@@ -1,4 +1,4 @@
 # Run below cmd in the root dir of app-netutil repo
 pushd ./samples/dpdk_app/dpdk-app-centos/
-docker build --rm -t dpdk-app-centos .
+docker build --build-arg MLX_STACK="${MLX_STACK}" --rm -t dpdk-app-centos .
 popd

--- a/samples/dpdk_app/dpdk-app-centos/Dockerfile
+++ b/samples/dpdk_app/dpdk-app-centos/Dockerfile
@@ -17,6 +17,16 @@ RUN yum install -y wget numactl-devel git golang make; yum clean all
 #RUN yum install -y pciutils iproute; yum clean all
 
 #
+# Install Mellanox libraries: The variable MLX_STAC controls what set of libraries to install.
+# Allowed values: upstream | ofed
+#
+WORKDIR /usr/src
+ARG MLX_STACK
+ENV MLX_STACK ${MLX_STACK:-upstream}
+COPY ./install_mlx_libs.sh ./install_mlx_libs.sh
+RUN ./install_mlx_libs.sh
+
+#
 # Download and Build APP-NetUtil
 #
 WORKDIR /root/go/src/
@@ -42,8 +52,10 @@ RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' config/common_linux
 RUN sed -i -e 's/KNI_KMOD=y/KNI_KMOD=n/' config/common_linux
 RUN sed -i -e 's/LIBRTE_KNI=y/LIBRTE_KNI=n/' config/common_linux
 RUN sed -i -e 's/LIBRTE_PMD_KNI=y/LIBRTE_PMD_KNI=n/' config/common_linux
+RUN sed -i -e 's/CONFIG_RTE_LIBRTE_MLX5_PMD=n/CONFIG_RTE_LIBRTE_MLX5_PMD=y/' config/common_base
 # Additional Debug if Needed
 #RUN sed -i -e 's/CONFIG_RTE_LIBRTE_ETHDEV_DEBUG=n/CONFIG_RTE_LIBRTE_ETHDEV_DEBUG=y/' config/common_base
+#RUN sed -i -e 's/CONFIG_RTE_LIBRTE_MLX5_DEBUG=n/CONFIG_RTE_LIBRTE_MLX5_DEBUG=y/' config/common_base
 
 # DPDK_VER 19.02
 #RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' config/common_linuxapp
@@ -109,6 +121,11 @@ COPY --from=0 /usr/bin/l3fwd /usr/bin/l3fwd
 COPY --from=0 /usr/bin/testpmd /usr/bin/testpmd
 COPY --from=0 /lib64/libnetutil_api.so /lib64/libnetutil_api.so
 COPY --from=0 /usr/lib64/libnuma.so.1 /usr/lib64/libnuma.so.1
+COPY --from=0 /usr/lib64/libibverbs.so.1 /usr/lib64/libibverbs.so.1
+COPY --from=0 /usr/lib64/libmlx4.so.1 /usr/lib64/libmlx4.so.1
+COPY --from=0 /usr/lib64/libmlx5.so.1 /usr/lib64/libmlx5.so.1
+COPY --from=0 /usr/lib64/libnl-3.so.200 /usr/lib64/libnl-3.so.200
+COPY --from=0 /usr/lib64/libnl-route-3.so.200 /usr/lib64/libnl-route-3.so.200
 # END
 
 COPY ./docker-entrypoint.sh /

--- a/samples/dpdk_app/dpdk-app-centos/README.md
+++ b/samples/dpdk_app/dpdk-app-centos/README.md
@@ -38,6 +38,17 @@ OR
    make dpdk_app
 ```
 
+If Mellanox cards are used, the dpdk application can be built using Mellanox OFED
+libraries or the ones provided by the upstream rdma-core package. In order to select
+which ones to use, the **MLX_STACK** envirionment variable can be used with the
+following values: "ofed" or "upstream" (if not set, it will default to "upstream").
+For example:
+
+```
+   cd $GOPATH/src/github.com/openshift/app-netutil/
+   export MLX_STACK="ofed" && make dpdk_app
+```
+
 ## Reduce Image Size
 Multi-stage builds are a new feature requiring **Docker 17.05** or higher on
 the daemon and client. If multi-stage builds are NOT supported on your system,

--- a/samples/dpdk_app/dpdk-app-centos/dpdk-args.c
+++ b/samples/dpdk_app/dpdk-app-centos/dpdk-args.c
@@ -327,6 +327,10 @@ char** GetArgs(int *pArgc, eDpdkAppType appType)
 		//strncpy(&myArgsArray[argc++][0], "-m", DPDK_ARGS_MAX_ARG_STRLEN-1);
 		//strncpy(&myArgsArray[argc++][0], "1024", DPDK_ARGS_MAX_ARG_STRLEN-1);
 
+		// Add --log-level pmd.net.mlx5:8 for debgging
+		//strncpy(&myArgsArray[argc++][0], "--log-level", DPDK_ARGS_MAX_ARG_STRLEN-1);
+		//strncpy(&myArgsArray[argc++][0], "pmd.net.mlx5:8", DPDK_ARGS_MAX_ARG_STRLEN-1);
+
 		strncpy(&myArgsArray[argc++][0], "-n", DPDK_ARGS_MAX_ARG_STRLEN-1);
 		strncpy(&myArgsArray[argc++][0], "4", DPDK_ARGS_MAX_ARG_STRLEN-1);
 

--- a/samples/dpdk_app/dpdk-app-centos/install_mlx_libs.sh
+++ b/samples/dpdk_app/dpdk-app-centos/install_mlx_libs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+OFED_VERSION="4.7-1.0.0.1"
+DIST="rhel8.0"
+ARCH="x86_64"
+WORKDIR="/usr/src"
+
+if [ ${MLX_STACK} == "upstream" ]; then
+	echo "Installing upstream libraries"
+	yum install -y libnl3 rdma-core-devel
+elif [ ${MLX_STACK} == "ofed" ]; then
+	echo "installing ofed libraries"
+	pushd ${WORKDIR}
+	yum install -y wget perl tk libnl3 numactl-libs tcl python36
+	wget http://www.mellanox.com/downloads/ofed/MLNX_OFED-${OFED_VERSION}/MLNX_OFED_LINUX-${OFED_VERSION}-${DIST}-${ARCH}.tgz
+	tar xf MLNX_OFED_LINUX-${OFED_VERSION}-${DIST}-${ARCH}.tgz
+	pushd ${WORKDIR}/MLNX_OFED_LINUX-${OFED_VERSION}-${DIST}-${ARCH}
+    	./mlnxofedinstall  --user-space-only \
+	       		   --dpdk \
+			   --upstream-libs \
+			   --distro ${DIST} \
+			   --without-fw-update \
+			    -q
+
+	cat /tmp/MLNX_OFED_LINUX.*.logs/general.log
+	popd
+	popd
+else
+	echo "Please, set MLX_STACK to a valid value: upstream | ofed"
+	exit 1
+fi

--- a/samples/dpdk_app/sriov/README.md
+++ b/samples/dpdk_app/sriov/README.md
@@ -22,7 +22,11 @@ This test setup assumes:
 
 This test setup uses two physical NICs (PFs) with one VF from each PF
 attached to the pod. It maps traffic from the PF to the each VF using
-VLANs. 
+VLANs.
+
+Both intel and Mellanox hardware is supported by a different set of
+configuration files. The use of both cards simultaneously is not
+supported.
 
 ## Download the sample yaml files
 Use the following steps to download the sample YAML files:
@@ -37,10 +41,19 @@ is `$GOPATH/src/github.com/openshift/app-netutil/samples/dpdk_app/sriov/`.
 
 ## Create the Network-Attachment-Definition for each desired network
 This setup assumes there are two networks, one network for each PF. The
-following commands setup those networks:
+following commands setup those networks.
+
+For Intel cards:
+
 ```
 kubectl create -f netAttach-sriov-dpdk-a.yaml
 kubectl create -f netAttach-sriov-dpdk-b.yaml
+```
+For Mellanox cards:
+
+```
+kubectl create -f netAttach-sriov-dpdk-mlx-a.yaml
+kubectl create -f netAttach-sriov-dpdk-mlx-b.yaml
 ```
 
 These YAML files map a VLAN to the VF. It is currently using VLAN 100 for
@@ -68,10 +81,11 @@ then update the file accordingly.
 ```
 kubectl create -f ./configMap.yaml
 ```
+Use `configMap-mlx.yaml` as a base for Mellanox cards.
 
 The following command can be used to collect info on which interfaces are
 in your system and manufacturer details that are used in the configMap to
-select available VFs. 
+select available VFs.
 ```
 lspci -nn | grep Ethernet
 01:00.0 Ethernet controller [0200]: Intel Corporation Ethernet Controller X710 for 10GbE SFP+ [8086:1572] (rev 01)

--- a/samples/dpdk_app/sriov/README.md
+++ b/samples/dpdk_app/sriov/README.md
@@ -127,15 +127,15 @@ looking for VFs that meet the selector’s criteria. This takes a
 couple of seconds to collect. The following command can be used to
 determine the number of detected VFs. (NOTE: This is the allocated
 values and does not change as VFs are doled out.) See
-"intel.com/intel_sriov_dpdk_a" and "intel.com/intel_sriov_dpdk_b":
+"openshift.io/sriov_dpdk_a" and "openshift.io/sriov_dpdk_b":
 ```
 kubectl get node nfvsdn-22-oot -o json | jq '.status.allocatable'
 {
   "cpu": "64",
   "ephemeral-storage": "396858657750",
   "hugepages-1Gi": "64Gi",
-  "intel.com/intel_sriov_dpdk_a": "8",
-  "intel.com/intel_sriov_dpdk_b": "8",
+  "openshift.io/sriov_dpdk_a": "8",
+  "openshift.io/sriov_dpdk_b": "8",
   "memory": "64773512Ki",
   "pods": "110"
 }

--- a/samples/dpdk_app/sriov/configMap-mlx.yaml
+++ b/samples/dpdk_app/sriov/configMap-mlx.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [{
+                "resourceName": "sriov_dpdk_a",
+                "isRdma": true,
+                "selectors": {
+                    "vendors": ["15b3"],
+                    "devices": ["a2d2", "a2d3"],
+                    "drivers": ["mlx5_core"],
+                    "pfNames": ["enp66s0f0"]
+                }
+            },
+            {
+                "resourceName": "sriov_dpdk_b",
+                "isRdma": true,
+                "selectors": {
+                    "vendors": ["15b3"],
+                    "devices": ["a2d2", "a2d3"],
+                    "drivers": ["mlx5_core"],
+                    "pfNames": ["enp66s0f1"]
+                }
+            }
+
+        ]
+    }
+

--- a/samples/dpdk_app/sriov/configMap.yaml
+++ b/samples/dpdk_app/sriov/configMap.yaml
@@ -7,7 +7,7 @@ data:
   config.json: |
     {
         "resourceList": [{
-                "resourceName": "intel_sriov_dpdk_a",
+                "resourceName": "sriov_dpdk_a",
                 "selectors": {
                     "vendors": ["8086"],
                     "devices": ["154c", "1572"],
@@ -16,7 +16,7 @@ data:
                 }
             },
             {
-                "resourceName": "intel_sriov_dpdk_b",
+                "resourceName": "sriov_dpdk_b",
                 "selectors": {
                     "vendors": ["8086"],
                     "devices": ["154c", "1572"],

--- a/samples/dpdk_app/sriov/netAttach-sriov-dpdk-a.yaml
+++ b/samples/dpdk_app/sriov/netAttach-sriov-dpdk-a.yaml
@@ -3,7 +3,7 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: sriov-net-a
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/intel_sriov_dpdk_a
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriov_dpdk_a
 spec:
   config: '{
   "type": "sriov",

--- a/samples/dpdk_app/sriov/netAttach-sriov-dpdk-b.yaml
+++ b/samples/dpdk_app/sriov/netAttach-sriov-dpdk-b.yaml
@@ -3,7 +3,7 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: sriov-net-b
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/intel_sriov_dpdk_b
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriov_dpdk_b
 spec:
   config: '{
   "type": "sriov",

--- a/samples/dpdk_app/sriov/netAttach-sriov-dpdk-mlx-a.yaml
+++ b/samples/dpdk_app/sriov/netAttach-sriov-dpdk-mlx-a.yaml
@@ -1,0 +1,16 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriov_dpdk_a
+spec:
+  config: '{
+  "type": "sriov",
+  "cniVersion": "0.3.1",
+  "name": "sriov-network-a",
+  "vlan": 100,
+  "vlanQoS": 1,
+  "spoofchk": "off",
+  "trust": "on"
+}'

--- a/samples/dpdk_app/sriov/netAttach-sriov-dpdk-mlx-b.yaml
+++ b/samples/dpdk_app/sriov/netAttach-sriov-dpdk-mlx-b.yaml
@@ -1,0 +1,16 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-b
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriov_dpdk_b
+spec:
+  config: '{
+  "type": "sriov",
+  "cniVersion": "0.3.1",
+  "name": "sriov-network-b",
+  "vlan": 200,
+  "vlanQoS": 1,
+  "spoofchk": "off",
+  "trust": "on"
+}'

--- a/samples/dpdk_app/sriov/sriov-pod-1.yaml
+++ b/samples/dpdk_app/sriov/sriov-pod-1.yaml
@@ -21,13 +21,13 @@ spec:
       requests:
         memory: 1Gi
         #cpu: "4"
-        intel.com/intel_sriov_dpdk_a: '1'
-        intel.com/intel_sriov_dpdk_b: '1'
+        openshift.io/sriov_dpdk_a: '1'
+        openshift.io/sriov_dpdk_b: '1'
       limits:
         hugepages-1Gi: 2Gi
         #cpu: "4"
-        intel.com/intel_sriov_dpdk_a: '1'
-        intel.com/intel_sriov_dpdk_b: '1'
+        openshift.io/sriov_dpdk_a: '1'
+        openshift.io/sriov_dpdk_b: '1'
     # Uncomment to control which DPDK App is running in container.
     # If not provided, l3fwd is default.
     #   Options: l2fwd l3fwd testpmd

--- a/samples/dpdk_app/sriov/sriovdp-daemonset.yaml
+++ b/samples/dpdk_app/sriov/sriovdp-daemonset.yaml
@@ -42,6 +42,7 @@ spec:
         args:
         - --log-dir=sriovdp
         - --log-level=10
+        - --resource-prefix=openshift.io
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
In order to add support for Mellanox cards, first change the names to vendor neutral (using openshift.io instead of intel.com when possible).
Add support for Mellanox cards. Do not try to avoid the name collision in the sample application as it is assumed that intel *or* mellanox cards will be used (not both simultaneously).
The environment variable MLX_STACK can be used to select between upstream and Mellanox's divers/libs.

